### PR TITLE
Fix LSP server restart mechanism for Justfile changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,6 +95,23 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (enableLsp) {
         startLsp();
+        
+        // Watch for Justfile changes and restart LSP if needed
+        const justfileWatcher = vscode.workspace.createFileSystemWatcher('**/*.{just,justfile,Justfile}');
+        
+        const restartLspOnFileChange = async () => {
+            if (client) {
+                logger.info('Justfile changed, restarting LSP client', 'Extension');
+                await stopLsp();
+                await startLsp();
+            }
+        };
+        
+        justfileWatcher.onDidChange(restartLspOnFileChange);
+        justfileWatcher.onDidCreate(restartLspOnFileChange);
+        justfileWatcher.onDidDelete(restartLspOnFileChange);
+        
+        context.subscriptions.push(justfileWatcher);
     } else {
         logger.info('LSP subsystem disabled by configuration', 'Extension');
     }


### PR DESCRIPTION
## Summary
- Implement automatic LSP client restart when Justfile is modified/created/deleted
- Enhance error handling with user notifications and restart after 3+ errors  
- Add diagnostic monitoring to ensure problems appear in VS Code Problems panel

## Problem Solved
Fixes issue where the justlang-lsp integration doesn't restart or reload after a Justfile is modified. Even if syntax errors in a Justfile are fixed, the VS Code problems panel shows the same errors at the same lines and they never update.

## Changes
- **src/extension.ts**: Added Justfile file watcher and restart mechanism
- **src/client.ts**: Enhanced error handling and diagnostic monitoring

## Test Plan
- [x] Modify a Justfile with syntax errors
- [x] Fix the errors 
- [x] Verify that problems panel updates correctly
- [x] Verify that LSP server restarts on file changes
- [x] TypeScript compilation passes
- [x] Linting passes

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)